### PR TITLE
Fix missing organization in GitHub link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-All code for this extension lives in another repo: https://github.com/gh-gei
+All code for this extension lives in another repo: https://github.com/github/gh-gei


### PR DESCRIPTION
The link in the README was returning a 404 because it was missing the name of the organization.